### PR TITLE
remove infinite while

### DIFF
--- a/cli/model.py
+++ b/cli/model.py
@@ -224,12 +224,9 @@ def output(connect, slot=None, nowait=False, noexit=False, **kwargs):
             print data
     else:
         try:
-            while True:
-                data = engine.output(slot)
-                if data != None:
-                    print data
-                    if not noexit:
-                        break
+            data = engine.output(slot)
+            if data != None:
+                print data
         except EOFError:
             print tcol.OKBLUE + "(EOF)" + tcol.ENDC
         except KeyboardInterrupt:


### PR DESCRIPTION
Issue - https://opendatagoup.atlassian.net/browse/FSN-391.
The variable `data` always have `None` value when try set invalid input data as provided in ticket above. The module `rest_stream.erl` have timeout but if we still need some timeout for waiting output data in CLI - we can use other approach, something like:
```python
# ...
            end_time = time.time() + 5  # ----- timeout of 5 seconds timeout
            while time.time() < end_time:
                data = engine.output(slot)
                if data != None:
                    print data
                    if not noexit:
                        break
# ...
```
But as I understand that in GO SDK/SLI don't have `while` loop for this scenario 